### PR TITLE
Create missing Published folder if it is not generated after first launch

### DIFF
--- a/MirrorsEdgeTweaks/MainWindow.xaml.cs
+++ b/MirrorsEdgeTweaks/MainWindow.xaml.cs
@@ -3967,15 +3967,25 @@ namespace MirrorsEdgeTweaks
             try
             {
                 string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-                string publishedPath = Path.Combine(documentsPath, "EA Games", "Mirror's Edge", "TdGame", "Published");
+                string tdGamePath = Path.Combine(documentsPath, "EA Games", "Mirror's Edge", "TdGame");
+                string publishedPath = Path.Combine(tdGamePath, "Published");
 
                 if (!Directory.Exists(publishedPath))
                 {
-                    DialogHelper.ShowMessage("Error", 
-                        $"Published folder not found at: {publishedPath}\n\n" +
-                        "Please ensure you have launched Mirror's Edge at least once.",
-                        DialogHelper.MessageType.Error);
-                    return;
+                    if (Directory.Exists(tdGamePath))
+                    {
+                        // If there's no Published folder but TdGame exists,
+                        // just create the missing published folder
+                        Directory.CreateDirectory(publishedPath);
+                    }
+                    else
+                    {
+                        DialogHelper.ShowMessage("Error",
+                            $"Published folder not found at: {publishedPath}\n\n" +
+                            "Please ensure you have launched Mirror's Edge at least once.",
+                            DialogHelper.MessageType.Error);
+                        return;
+                    }
                 }
 
                 ShowProgress("Downloading Tweaks Scripts UI...", false);


### PR DESCRIPTION
# Problem

I have a GOG install of Mirror's Edge, and I've found that even after I start the game, I see no Published folder in my `C:\Users\%UserName%\Documents\EA Games\Mirror's Edge\TdGame` directory:

<img width="1408" height="742" alt="image" src="https://github.com/user-attachments/assets/cb556710-4283-4652-9eac-d753b9ad3b10" />

# Investigation

I'm a complete novice to modding Mirror's Edge, so please do correct me if I'm wrong, but from some research, it seems that some threads suggest that it's okay to simply create the Published folder if it doesn't exist.

## Links
https://unrealedge.fandom.com/wiki/Setting_up_the_Editor

> Create two new folders called Published and Unpublished if you don't have them already

https://www.modacity.net/forums/showthread.php?15442-Mirror-s-Edge-Level-Editor&15442-Mirror-s-Edge-Level-Editor=&p=387703#post387703

> If some of the folders don't exist, make them yourself.

https://www.moddb.com/games/mirrors-edge/addons/authority

>  Create two new folders. One folder named "Unpublished", another is "Published".

# Proposed Solution

I propose that if the user has no Published directory but has started the game up before, we should just create the missing Published folder for them. To determine whether or not the user has started the game before, I added a check to make sure that at least the `C:\Users\%UserName%\Documents\EA Games\Mirror's Edge\TdGame` directory exists. I did some testing and sure enough, this path does get created for me each time I start the game (even if I delete it).

## Testing

I did some testing on my own, and everything seems to be working correctly, but if there are additional test cases which I should check, I'd be delighted to test these to guard against regressions. If you'd like a video or any other verification of the testing, I can provide that too. This tool is amazing, and I'd love to keep it that way!